### PR TITLE
Add contributors to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 .jekyll-cache
+.idea/

--- a/about/working-groups/index.md
+++ b/about/working-groups/index.md
@@ -35,3 +35,8 @@ micro_nav: false
 
 <div id="industry-wg">  
 </div>
+
+## Contributors
+
+<div id="contributors-wg">  
+</div>

--- a/about/working-groups/working-groups.json
+++ b/about/working-groups/working-groups.json
@@ -28,9 +28,9 @@
     ]
   },
   {
-    "displayName": "Niklas Düster",
-    "lastName": "Düster",
-    "headshot": "niklas-düster.jpg",
+    "displayName": "Niklas D\u00fcster",
+    "lastName": "D\u00fcster",
+    "headshot": "niklas-d\u00fcster.jpg",
     "organization": "PAYONE",
     "description": null,
     "twitter": "nscur0",
@@ -137,6 +137,692 @@
     "homepage": "https://www.fujitsu.com/uk/solutions/industry/defence-national-security/",
     "categories": [
       "industry"
+    ]
+  },
+  {
+    "displayName": "DarthHater",
+    "lastName": "darthhater",
+    "headshot": "https://avatars.githubusercontent.com/u/5544326?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "DarthHater",
+    "homepage": "https://github.com/DarthHater",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "bhamail",
+    "lastName": "bhamail",
+    "headshot": "https://avatars.githubusercontent.com/u/578919?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "bhamail",
+    "homepage": "https://github.com/bhamail",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "mr-zepol",
+    "lastName": "mr-zepol",
+    "headshot": "https://avatars.githubusercontent.com/u/21176019?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "mr-zepol",
+    "homepage": "https://github.com/mr-zepol",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jrojassonatype",
+    "lastName": "jrojassonatype",
+    "headshot": "https://avatars.githubusercontent.com/u/57679720?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jrojassonatype",
+    "homepage": "https://github.com/jrojassonatype",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "mterron",
+    "lastName": "mterron",
+    "headshot": "https://avatars.githubusercontent.com/u/4434907?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "mterron",
+    "homepage": "https://github.com/mterron",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "cmbaatz",
+    "lastName": "cmbaatz",
+    "headshot": "https://avatars.githubusercontent.com/u/40895835?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "cmbaatz",
+    "homepage": "https://github.com/cmbaatz",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "hboutemy",
+    "lastName": "hboutemy",
+    "headshot": "https://avatars.githubusercontent.com/u/237462?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "hboutemy",
+    "homepage": "https://github.com/hboutemy",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "sschuberth",
+    "lastName": "sschuberth",
+    "headshot": "https://avatars.githubusercontent.com/u/349154?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "sschuberth",
+    "homepage": "https://github.com/sschuberth",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "renjith85",
+    "lastName": "renjith85",
+    "headshot": "https://avatars.githubusercontent.com/u/3585316?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "renjith85",
+    "homepage": "https://github.com/renjith85",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "Bertk",
+    "lastName": "bertk",
+    "headshot": "https://avatars.githubusercontent.com/u/2315215?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "Bertk",
+    "homepage": "https://github.com/Bertk",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "karolswdev",
+    "lastName": "karolswdev",
+    "headshot": "https://avatars.githubusercontent.com/u/50302144?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "karolswdev",
+    "homepage": "https://github.com/karolswdev",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "MangoFloat",
+    "lastName": "mangofloat",
+    "headshot": "https://avatars.githubusercontent.com/u/33149714?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "MangoFloat",
+    "homepage": "https://github.com/MangoFloat",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "brianvu-dysi",
+    "lastName": "brianvu-dysi",
+    "headshot": "https://avatars.githubusercontent.com/u/59894428?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "brianvu-dysi",
+    "homepage": "https://github.com/brianvu-dysi",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "morganthrapp",
+    "lastName": "morganthrapp",
+    "headshot": "https://avatars.githubusercontent.com/u/8458546?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "morganthrapp",
+    "homepage": "https://github.com/morganthrapp",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "patspaeth",
+    "lastName": "patspaeth",
+    "headshot": "https://avatars.githubusercontent.com/u/80386770?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "patspaeth",
+    "homepage": "https://github.com/patspaeth",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "rocallaghan-deluxe",
+    "lastName": "rocallaghan-deluxe",
+    "headshot": "https://avatars.githubusercontent.com/u/55455181?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "rocallaghan-deluxe",
+    "homepage": "https://github.com/rocallaghan-deluxe",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "ST-Apps",
+    "lastName": "st-apps",
+    "headshot": "https://avatars.githubusercontent.com/u/20584116?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "ST-Apps",
+    "homepage": "https://github.com/ST-Apps",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "scorgatelli-docutech",
+    "lastName": "scorgatelli-docutech",
+    "headshot": "https://avatars.githubusercontent.com/u/52677769?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "scorgatelli-docutech",
+    "homepage": "https://github.com/scorgatelli-docutech",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jskovjyskebankdk",
+    "lastName": "jskovjyskebankdk",
+    "headshot": "https://avatars.githubusercontent.com/u/8705199?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jskovjyskebankdk",
+    "homepage": "https://github.com/jskovjyskebankdk",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "stefanneuhaus",
+    "lastName": "stefanneuhaus",
+    "headshot": "https://avatars.githubusercontent.com/u/8896988?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "stefanneuhaus",
+    "homepage": "https://github.com/stefanneuhaus",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "angrylogic",
+    "lastName": "angrylogic",
+    "headshot": "https://avatars.githubusercontent.com/u/4575020?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "angrylogic",
+    "homepage": "https://github.com/angrylogic",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "prabhu",
+    "lastName": "prabhu",
+    "headshot": "https://avatars.githubusercontent.com/u/7842?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "prabhu",
+    "homepage": "https://github.com/prabhu",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jonasac",
+    "lastName": "jonasac",
+    "headshot": "https://avatars.githubusercontent.com/u/1088181?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jonasac",
+    "homepage": "https://github.com/jonasac",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "mfriedenhagen",
+    "lastName": "mfriedenhagen",
+    "headshot": "https://avatars.githubusercontent.com/u/125281?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "mfriedenhagen",
+    "homepage": "https://github.com/mfriedenhagen",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "iabudiab",
+    "lastName": "iabudiab",
+    "headshot": "https://avatars.githubusercontent.com/u/5612057?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "iabudiab",
+    "homepage": "https://github.com/iabudiab",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "eoftedal",
+    "lastName": "eoftedal",
+    "headshot": "https://avatars.githubusercontent.com/u/238804?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "eoftedal",
+    "homepage": "https://github.com/eoftedal",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "vaaralav",
+    "lastName": "vaaralav",
+    "headshot": "https://avatars.githubusercontent.com/u/8571541?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "vaaralav",
+    "homepage": "https://github.com/vaaralav",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "RaineInto",
+    "lastName": "raineinto",
+    "headshot": "https://avatars.githubusercontent.com/u/47811100?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "RaineInto",
+    "homepage": "https://github.com/RaineInto",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "anush-cr",
+    "lastName": "anush-cr",
+    "headshot": "https://avatars.githubusercontent.com/u/9949303?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "anush-cr",
+    "homepage": "https://github.com/anush-cr",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "c0d3nh4ck",
+    "lastName": "c0d3nh4ck",
+    "headshot": "https://avatars.githubusercontent.com/u/50226641?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "c0d3nh4ck",
+    "homepage": "https://github.com/c0d3nh4ck",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "AndrewJohnBenjamin",
+    "lastName": "andrewjohnbenjamin",
+    "headshot": "https://avatars.githubusercontent.com/u/8436521?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "AndrewJohnBenjamin",
+    "homepage": "https://github.com/AndrewJohnBenjamin",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "kro29200",
+    "lastName": "kro29200",
+    "headshot": "https://avatars.githubusercontent.com/u/12068332?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "kro29200",
+    "homepage": "https://github.com/kro29200",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "chemsoc",
+    "lastName": "chemsoc",
+    "headshot": "https://avatars.githubusercontent.com/u/647701?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "chemsoc",
+    "homepage": "https://github.com/chemsoc",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "Szasza",
+    "lastName": "szasza",
+    "headshot": "https://avatars.githubusercontent.com/u/911466?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "Szasza",
+    "homepage": "https://github.com/Szasza",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "RobertMaaskant",
+    "lastName": "robertmaaskant",
+    "headshot": "https://avatars.githubusercontent.com/u/365056?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "RobertMaaskant",
+    "homepage": "https://github.com/RobertMaaskant",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "davidkarlsen",
+    "lastName": "davidkarlsen",
+    "headshot": "https://avatars.githubusercontent.com/u/18299?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "davidkarlsen",
+    "homepage": "https://github.com/davidkarlsen",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jhermann",
+    "lastName": "jhermann",
+    "headshot": "https://avatars.githubusercontent.com/u/1068245?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jhermann",
+    "homepage": "https://github.com/jhermann",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "praveenmylavarapu",
+    "lastName": "praveenmylavarapu",
+    "headshot": "https://avatars.githubusercontent.com/u/3250456?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "praveenmylavarapu",
+    "homepage": "https://github.com/praveenmylavarapu",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "emnetag",
+    "lastName": "emnetag",
+    "headshot": "https://avatars.githubusercontent.com/u/7269445?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "emnetag",
+    "homepage": "https://github.com/emnetag",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "TTMaZa",
+    "lastName": "ttmaza",
+    "headshot": "https://avatars.githubusercontent.com/u/43759631?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "TTMaZa",
+    "homepage": "https://github.com/TTMaZa",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "msander",
+    "lastName": "msander",
+    "headshot": "https://avatars.githubusercontent.com/u/368751?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "msander",
+    "homepage": "https://github.com/msander",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "tngraf",
+    "lastName": "tngraf",
+    "headshot": "https://avatars.githubusercontent.com/u/1225388?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "tngraf",
+    "homepage": "https://github.com/tngraf",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jkobti",
+    "lastName": "jkobti",
+    "headshot": "https://avatars.githubusercontent.com/u/5858677?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jkobti",
+    "homepage": "https://github.com/jkobti",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "ssproessig",
+    "lastName": "ssproessig",
+    "headshot": "https://avatars.githubusercontent.com/u/1576323?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "ssproessig",
+    "homepage": "https://github.com/ssproessig",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "josephkobti",
+    "lastName": "josephkobti",
+    "headshot": "https://avatars.githubusercontent.com/u/54405348?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "josephkobti",
+    "homepage": "https://github.com/josephkobti",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "csansone-handy",
+    "lastName": "csansone-handy",
+    "headshot": "https://avatars.githubusercontent.com/u/51127567?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "csansone-handy",
+    "homepage": "https://github.com/csansone-handy",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "jkbuster",
+    "lastName": "jkbuster",
+    "headshot": "https://avatars.githubusercontent.com/u/1432093?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "jkbuster",
+    "homepage": "https://github.com/jkbuster",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "sabinranjit",
+    "lastName": "sabinranjit",
+    "headshot": "https://avatars.githubusercontent.com/u/77010176?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "sabinranjit",
+    "homepage": "https://github.com/sabinranjit",
+    "categories": [
+      "contributors"
+    ]
+  },
+  {
+    "displayName": "kakumara",
+    "lastName": "kakumara",
+    "headshot": "https://avatars.githubusercontent.com/u/6473228?v=4",
+    "organization": null,
+    "description": null,
+    "twitter": null,
+    "linkedin": null,
+    "github": "kakumara",
+    "homepage": "https://github.com/kakumara",
+    "categories": [
+      "contributors"
     ]
   }
 ]

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+cd _site
+python3 -m http.server 8000

--- a/theme/assets/js/working-groups.js
+++ b/theme/assets/js/working-groups.js
@@ -2,12 +2,15 @@ function populateCards() {
   let coreWG = document.getElementById("core-wg");
   let maintainers = document.getElementById("maintainers-wg");
   let industryWG = document.getElementById("industry-wg");
+  let contributors = document.getElementById("contributors-wg");
   let coreWGhtml = "";
   let maintainershtml = "";
   let industryWGhtml = "";
+  let contributorshtml= "";
   let coreWGcount = 0;
   let maintainerscount = 0;
   let industryWGcount = 0;
+  let contributorsCount = 0;
   let xmlhttp = new XMLHttpRequest();
   xmlhttp.onreadystatechange = function () {
     if (this.readyState === 4 && this.status === 200) {
@@ -47,6 +50,15 @@ function populateCards() {
               industryWGhtml += template;
             }
             industryWGcount++;
+          } else if (member.categories[aa] === "contributors") {
+            if (contributorsCount === 0) {
+              contributorshtml += rowBegin + template;
+            } else if (contributorsCount % 3 === 0) {
+              contributorshtml += rowEnd + rowBegin + template;
+            } else {
+              contributorshtml += template;
+            }
+            contributorsCount++;
           }
         }
       }
@@ -56,6 +68,7 @@ function populateCards() {
       coreWG.insertAdjacentHTML('beforeend', coreWGhtml);
       maintainers.insertAdjacentHTML('beforeend', maintainershtml);
       industryWG.insertAdjacentHTML('beforeend', industryWGhtml);
+      contributors.insertAdjacentHTML('beforeend', contributorshtml);
 
     }
   };
@@ -64,10 +77,18 @@ function populateCards() {
 }
 
 function generateTemplate(member) {
+  if (member.headshot.startsWith('https://'))
+  {
+    var headshotUrl = member.headshot;
+  }
+  else
+  {
+    var headshotUrl = "/theme/assets/images/headshots/" + member.headshot;
+  }
   return `
     <div class="col-sm-4 col-md-4">
       <div class="thumbnail">
-        <img class="profile" src="/theme/assets/images/headshots/${member.headshot}">
+        <img class="profile" src="${headshotUrl}">
         <div class="caption">
           ${generateName(member)}
           ${generateDescription(member)}

--- a/update_contributors.py
+++ b/update_contributors.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import json
+import os
+import urllib.request
+
+
+def get_repos():
+    token = os.environ.get('GITHUB_TOKEN', None)
+    request = urllib.request.Request('https://api.github.com/users/CycloneDX/repos')
+    if token is not None:
+        request.add_header('Authorization', 'token ' + token)
+    with urllib.request.urlopen(request) as resource:
+        return json.load(resource)
+
+
+def get_repo_contributors(url):
+    token = os.environ.get('GITHUB_TOKEN', None)
+    request = urllib.request.Request(url)
+    if token is not None:
+        request.add_header('Authorization', 'token ' + token)
+    with urllib.request.urlopen(request) as resource:
+        return json.load(resource)
+
+
+def get_cyclonedx_contributors():
+    contributors = {}
+    print('Fetching repos for: CycloneDX', end=' ')
+    repos = get_repos()
+    print(len(repos), 'repos.')
+    print()
+    for repo in repos:
+        print('Fetching contributors for:', repo['name'], end=' ')
+        repo_contributors = get_repo_contributors(repo['contributors_url'])
+        print(len(repo_contributors), 'contributors.')
+        for contributor in repo_contributors:
+            if contributor['type'] != 'Bot':
+                contributors[contributor['login']] = {
+                    'github': contributor['login'],
+                    'headshot': contributor['avatar_url'],
+                    'homepage': contributor['html_url'],
+                }
+    print()
+    print(len(contributors), 'total contributors')
+    return contributors
+
+
+def get_working_group_members():
+    with open('about/working-groups/working-groups.json', 'rt') as f:
+        return json.load(f)
+
+
+def remove_working_group_members_from_contributors(members, contributors):
+    for member in members:
+        try:
+            del contributors[member['github']]
+        except KeyError:
+            pass
+
+
+def add_new_contributors(members, contributors):
+    for contributor in contributors.values():
+        members.append({
+            'displayName': contributor['github'],
+            'lastName': contributor['github'].lower(),
+            'headshot': contributor['headshot'],
+            'organization': None,
+            'description': None,
+            'twitter': None,
+            'linkedin': None,
+            'github': contributor['github'],
+            'homepage': contributor['homepage'],
+            'categories': [
+                'contributors'
+            ]
+        })
+
+
+if __name__ == '__main__':
+    if 'GITHUB_TOKEN' not in os.environ:
+        print('API rate limits might be hit without GITHUB_TOKEN being set')
+    all_contributors = get_cyclonedx_contributors()
+    working_group_members = get_working_group_members()
+    remove_working_group_members_from_contributors(working_group_members, all_contributors)
+    add_new_contributors(working_group_members, all_contributors)
+    with open('about/working-groups/working-groups.json', 'wt') as f:
+        json.dump(working_group_members, f, indent=2)


### PR DESCRIPTION
Adds a contributors section to the working groups page.

The `update_contributors.py` script adds contributors who aren't already in the `working-groups.json` file. This means anyone can raise a PR to add more details about themselves, i.e. full name, twitter, etc.

It also means people in the other groups aren't duplicated in the contributors section.

If this is an ok approach I'll probably set up a GitHub workflow that automatically runs this once a week. And if there are new contributors raise a PR automatically.
