### PR TITLE
add apt2sbom

### DIFF
--- a/tool-center/tools.json
+++ b/tool-center/tools.json
@@ -1080,5 +1080,16 @@
     "categories": [
       "proprietary"
     ]
+  },
+  {
+    "name" : "apt2sbom",
+    "publisher" : "Eliot Lear",
+    "description" : "Build an SBOM out of APT and python information",
+    "websiteURL": "https://github.com/elear/apt2sbom",
+    "repoUrl" : "https://github.com/elear/apt2sbom",
+    "categories": [
+      "opensource",
+      "build-integration"
+      ],
   }
 ]


### PR DESCRIPTION
This tool generates SBOMs out of apt and optionally pip information.

Signed-off-by: Eliot Lear <lear@cisco.com>