### PR TITLE
Update tools.json

### DIFF
--- a/tool-center/tools.json
+++ b/tool-center/tools.json
@@ -1196,7 +1196,7 @@
     "repoUrl": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
     "websiteUrl": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
     "categories": [
-      "opensource",
+      "proprietary",
       "analysis",
       "build-integration"
     ]


### PR DESCRIPTION
Edit for GitLab. I am the Product Manager of the Composition Analysis team at GitLab and this feature is only available in our Enterprise Edition so it is not opensource.