### PR TITLE
Update external-references.html to fix JSON validation errors

### DIFF
--- a/theme/_includes/examples/external-references.html
+++ b/theme/_includes/examples/external-references.html
@@ -88,7 +88,7 @@
             {
               "alg": "SHA-384",
               "content": "d4835048a0f57c74b8fb617d5366ab81376fc92bebe9a93bf24ba7f9da6c9aeeb6179f5d1361f6533211b15f3224cbad"
-            }
+            },
             {
               "alg": "SHA-512",
               "content": "74a51ff45e4c11df9ba1f0094282c80489649cb157a75fa337992d2d4592a5a1b8cb4525de8db0ae25233553924d76c36e093ea7fa9df4e5b8b07fd2e074efd6"
@@ -120,7 +120,7 @@
             {
               "alg": "SHA-384",
               "content": "8640424aa9bf337678580c55d23e54b973703c6e586987d85700f24d5de383cd1add590ee5b98d1710a01aff212687f3"
-            }
+            },
             {
               "alg": "SHA-512",
               "content": "45c6e3d03ec4207234e926063c484446d8b55f4bfce3f929f44cbc2320565290cc4b71de70c1d983792c6d63504f47f6b94513d09847dbae69c8f7cdd51ce980"


### PR DESCRIPTION
The JSON did not validate as there were 2 missing commas between array entries in the "hashes" field.