### PR TITLE
Add Fortify on Demand to Tool Center

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1319,3 +1319,11 @@
   categories:
     - proprietary
     - build-integration
+- name: Fortify on Demand
+  publisher: Micro Focus
+  description: Application Security-as-a-Service (SaaS) that includes software composition analysis (SCA) which produces and consumes CycloneDX SBOMs for a wide range of languages and package managers.
+  websiteUrl: https://www.microfocus.com/en-us/cyberres/application-security
+  categories:
+    - proprietary
+    - analysis
+    - build-integration

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1321,7 +1321,7 @@
     - build-integration
 - name: Fortify on Demand
   publisher: Micro Focus
-  description: Application Security-as-a-Service (SaaS) that includes software composition analysis (SCA) which produces and consumes CycloneDX SBOMs for a wide range of languages and package managers.
+  description: Comprehensive Application Security-as-a-Service (SaaS) includes software composition analysis (SCA) that produces and consumes CycloneDX SBOMs for a wide range of languages and package managers.
   websiteUrl: https://www.microfocus.com/en-us/cyberres/application-security
   categories:
     - proprietary

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1321,8 +1321,8 @@
     - build-integration
 - name: Fortify on Demand
   publisher: Micro Focus
-  description: Comprehensive Application Security-as-a-Service (SaaS) includes software composition analysis (SCA) that produces and consumes CycloneDX SBOMs for a wide range of languages and package managers.
-  websiteUrl: https://www.microfocus.com/en-us/cyberres/application-security
+  description: AppSec platform, powered by expert research teams and machine learning/AI, aimed at protecting the integrity of your software supply chain by producing and consuming CycloneDX SBOMs for a wide range of languages and package managers.
+  websiteUrl: https://www.microfocus.com/en-us/cyberres/application-security/fortify-on-demand
   categories:
     - proprietary
     - analysis


### PR DESCRIPTION
Fortify on Demand's latest release adds the ability to produce CycloneDX SBOMs as an output from running software composition analysis and can also import customers' CycloneDX SBOMs, including vulnerability data, for unified open source management in the FoD SaaS platform.