### PR TITLE
Update tools.yml, remove SnykVulnCheck

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1015,16 +1015,6 @@
   categories:
   - opensource
   - build-integration
-- name: SnykVulnCheck
-  publisher: Andrii Grytsenko
-  description: SnykVulnCheck analyzes the contents of CycloneDX SBOMs and evaluates
-    components for known vulnerabilities by using public APIs to Snyk Vulnerability
-    DB.
-  repoUrl: https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck
-  websiteUrl: https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck
-  categories:
-  - opensource
-  - analysis
 - name: apko
   publisher: Chainguard
   description: Build OCI images using APK directly without Dockerfile. Generates CycloneDX


### PR DESCRIPTION
It looks like this unfortunately will no longer work, as the API is no longer available.

See: https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck/issues/3 for details

The endpoint now returns
```{"status":"gone","message":"Looking for direct access to the best vulnerability database? You can find out more on https://snyk.io/partners/"}```