### PR TITLE
Update website for SCANOSS

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -322,7 +322,7 @@
   publisher: SCANOSS
   description: An open source inventory engine built for modern development teams
   repoUrl: https://github.com/scanoss/engine
-  websiteUrl: https://www.scanoss.co.uk/
+  websiteUrl: https://scanoss.com/
   categories:
   - opensource
   - analysis


### PR DESCRIPTION
Update website URL for SCANOSS, which has migrated from `.co.uk` to `.com`

Signed-off-by: Mark Symons <mark.symons@fujitsu.com>