### PR TITLE
Remove analysis category for cyclonedx-npm-pipe tool

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1716,4 +1716,3 @@
   categories:
     - opensource
     - build-integration
-    - analysis


### PR DESCRIPTION
Remove analysis category for cyclonedx-npm-pipe tool, per agreement with author.

Signed-off-by: Mark Symons <mark.symons@fujitsu.com>