### PR TITLE
chore: add Macaron as a tool that supports CycloneDX SBOM

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1716,3 +1716,13 @@
   categories:
     - opensource
     - build-integration
+- name: macaron
+  publisher: Oracle
+  description: A supply chain security analysis tool and policy engine that checks conformance to
+    frameworks, such as SLSA. It integrates CycloneDX SBOM generator tools or takes an existing
+    CycloneDX SBOM as input if available.
+  repoUrl: https://github.com/oracle/macaron
+  websiteUrl: https://oracle.github.io/macaron/
+  categories:
+    - opensource
+    - analysis


### PR DESCRIPTION
This PR adds [Macaron](https://github.com/oracle/macaron), a  supply chain security analysis tool and policy engine that checks conformance to frameworks, such as SLSA. It integrates CycloneDX SBOM generator tools or takes an existing CycloneDX SBOM as input if available.