### PR TITLE
Preload carousel images to increase responsiveness

### DIFF
--- a/_data/carousel.yml
+++ b/_data/carousel.yml
@@ -10,7 +10,7 @@
 - title: CycloneDX is enterprise ready and surfaces risk for IT and OT assets.
   image: theme/assets/images/enterprise_hero.jpg
   description: CycloneDX is trusted by leading CMDB vendors to detect security issues in hardware, software, services, and operations.
-- title: CycloneDX offer the most advanced license support of any SBOM format.
+- title: CycloneDX offers the most advanced license support of any SBOM format.
   image: theme/assets/images/license_hero.jpg
   description: CycloneDX can leverage SPDX license IDs and expressions, along with comprehensive commercial license support, supporting open source license compliance and Software Asset Management (SAM) use cases.
 - title: CycloneDX evolves with your project or organizational needs.

--- a/theme/_layouts/home.html
+++ b/theme/_layouts/home.html
@@ -11,6 +11,11 @@
 <body class="{{ site.doks.color_theme }}" data-spy="scroll" data-target=".js-scrollspy">
 
 <link rel="preload" as="image" href="/theme/assets/images/hero-header.png">
+<link rel="preload" as="image" href="/theme/assets/images/medical_hero.jpg">
+<link rel="preload" as="image" href="/theme/assets/images/defense_hero.jpg">
+<link rel="preload" as="image" href="/theme/assets/images/enterprise_hero.jpg">
+<link rel="preload" as="image" href="/theme/assets/images/license_hero.jpg">
+<link rel="preload" as="image" href="theme/assets/images/beyond_sbom_hero.jpg">
 <header class="header-container">
     {% include site-header.html %}
     <div class="hero-subheader" id="subheader">


### PR DESCRIPTION
Sometimes, when viewing the CycloneDX.org webpage from a small-screen mobile device, the carousel has a split second where images do not load properly between slides. This update should resolve the issue.