### PR TITLE
Add sbom-rs to tools list

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1826,3 +1826,12 @@
   categories:
     - opensource
     - transform
+- name: sbom-rs
+  publisher: Paul Sastrasinh
+  description: A group of Rust projects for interacting with and producing software bill of materials (SBOMs).
+  repoUrl: https://github.com/psastras/sbom-rs
+  websiteUrl: https://github.com/psastras/sbom-rs
+  categories:
+  - opensource
+  - build-integration
+  - github-action


### PR DESCRIPTION
This adds an additional open source tool that can produce CycloneDX BOMs from a Rust Cargo project.  A standalone CLI tool, and GitHub Action is included.

I am not the author of the tool, just a happy user.