### PR TITLE
docs: use case properties link to taxonomy

### DIFF
--- a/use-cases/index.md
+++ b/use-cases/index.md
@@ -237,11 +237,14 @@ between components. Additionally, services that depend on other services can als
 {% include examples/services.html %}
 
 ## Properties / name-value store
+
 The CycloneDX standard is fully extensible allowing for complex data to be represented in the BOM that is not provided
-by the core specification. In many cases however, name-value pairs are a simpler option. CycloneDX supports Properties
-which is a name-value store that can be used to describe additional data about the components, services, or the BOM
-that isn't native to the core specification. Unlike key-value stores, properties support duplicate names, each 
-potentially having different values.
+by the core specification. In many cases however, name-value pairs are a simpler option.  
+CycloneDX supports Properties which is a name-value store that can be used to describe additional data about the
+components, services, or the BOM that isn't native to the core specification.
+Unlike key-value stores, properties support duplicate names, each potentially having different values.  
+Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://cyclonedx.github.io/cyclonedx-property-taxonomy).
+Formal registration is OPTIONAL.
 
 {% include examples/properties.html %}
 


### PR DESCRIPTION
link to the web-=rendered version of the CycloneDX property taxonomy, where it is needed