### PR TITLE
Add rollup-plugin-sbom to the tools list for frontend projects

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1868,3 +1868,12 @@
   - opensource
   - analysis
   - distribution
+- name: Rollup Plugin SBOM
+  publisher: Jan Biasi
+  description: Creates CycloneDX SBOMs for frontend Javascript applications that have
+    been bundled with rollup or vite.
+  repoUrl: https://github.com/janbiasi/rollup-plugin-sbom
+  websiteUrl: https://github.com/janbiasi/rollup-plugin-sbom
+  categories:
+  - opensource
+  - build-integration


### PR DESCRIPTION
The Rollup Plugin SBOM provides build integration tooling into [Rollup](https://rollupjs.org/) and [Vite](https://vitejs.dev/) frontend projects to generate SBOM's with packages shipped to production. It would be very nice to also get this tool listed on the official site.

**Repository**: https://github.com/janbiasi/rollup-plugin-sbom
**Package on NPM**: https://www.npmjs.com/package/rollup-plugin-sbom