### PR TITLE
chore(tools): add Chainloop to tools section

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1909,3 +1909,14 @@
   - opensource
   - transform
   - library
+
+- name: Chainloop
+  publisher: Chainloop
+  description: Chainloop is an Open Source evidence store for your Software Supply Chain metadata, SBOMs, VEX, QA reports, and more.
+    Leverage third party integrations such as Dependency-Track for SBOM analysis or a blob storage/OCI registry.
+  repoUrl: https://github.com/chainloop-dev/chainloop
+  websiteUrl: https://github.com/chainloop-dev/chainloop
+  categories:
+  - opensource
+  - signing-notary
+  - build-integration


### PR DESCRIPTION
After adding Chainloop to supported projects #297, now it's turn to add it to the tools center.

![image](https://github.com/CycloneDX/cyclonedx.org/assets/24523/a6eb74e3-2988-43bf-a11e-ea0ab74495e9)


Thanks,
Miguel 