### PR TITLE
Update tools.yml for Conan

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -766,15 +766,24 @@
   categories:
   - proprietary
   - analysis
-- name: CycloneDX for Conan
+- name: CycloneDX for Conan1
+  publisher: CycloneDX
+  description: Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects
+    using Conan (archived project)
+  repoUrl: https://github.com/CycloneDX/cyclonedx-conan
+  websiteUrl: https://github.com/CycloneDX/cyclonedx-conan
+  categories:
+  - opensource
+  - build-integration
+- name: CycloneDX for Conan2
   publisher: Conan-IO
   description: Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects
-    using Conan extensions
+    using Conan-extension
   repoUrl: https://github.com/conan-io/conan-extensions
   websiteUrl: https://github.com/conan-io/conan-extensions
   categories:
   - opensource
-  - build-integration
+  - build-integration  
 - name: Checkov
   publisher: Checkov
   description: Prevent cloud misconfigurations during build-time for Terraform, Cloudformation,

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -767,11 +767,11 @@
   - proprietary
   - analysis
 - name: CycloneDX for Conan
-  publisher: CycloneDX
+  publisher: Conan-IO
   description: Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects
-    using Conan
-  repoUrl: https://github.com/CycloneDX/cyclonedx-conan
-  websiteUrl: https://github.com/CycloneDX/cyclonedx-conan
+    using Conan extensions
+  repoUrl: https://github.com/conan-io/conan-extensions
+  websiteUrl: https://github.com/conan-io/conan-extensions
   categories:
   - opensource
   - build-integration


### PR DESCRIPTION
The CycloneDX plugin for Conan was discontinued nine months ago in favor of the conan-extensions, which added support for CycloneDX in their tooling. The CycloneDX project was archived and documents this circumstance in the Readme. Therefore, I suggest this change to point interested parties directly to the recommended extensions without the hop over discontinued projects.