### PR TITLE
tool-card: fork/stars for GitHub-gist & GitLab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem "jekyll-sitemap"
 gem "jekyll-last-modified-at"
 gem 'jekyll-feed'
 gem 'jekyll-redirect-from'
+gem 'jekyll-regex-replace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       posix-spawn (~> 0.3.9)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-regex-replace (1.1.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -80,7 +81,8 @@ DEPENDENCIES
   jekyll-feed
   jekyll-last-modified-at
   jekyll-redirect-from
+  jekyll-regex-replace
   jekyll-sitemap
 
 BUNDLED WITH
-   2.2.30
+   2.3.25

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,7 @@ plugins:
   - jekyll-last-modified-at
   - jekyll-feed
   - jekyll-redirect-from
+  - jekyll-regex-replace
 defaults:
   -
     scope:

--- a/theme/_includes/tool-card.html
+++ b/theme/_includes/tool-card.html
@@ -11,13 +11,39 @@
       <div class="card-body">{{tool.description | truncate:250}}</div>
       <div style="line-height: 3.0rem">&nbsp;</div>
       <div class="card-footer">
-        {% assign url_prefix = tool.repoUrl | slice:0,19 %}
-        {% if url_prefix == 'https://github.com/' %}
-        {%comment%}repo holds the "org/repo" name, for eg anchore/syft{%endcomment%}
-        {% assign repo = tool.repoUrl | replace:'https://github.com/','' | replace: '.git','' %}
-        <img src="https://img.shields.io/github/forks/{{repo}}.svg?style=social&label=Forks">&nbsp;
-        <img src="https://img.shields.io/github/stars/{{repo}}.svg?style=social&label=Stars">
-        {% endif%}
+        {% if tool.repoUrl contains '://github.com/' %}
+          {%comment%}
+              repo holds the "org/repo" name, for eg:
+                  https://github.com/anchore/syft
+                  https://github.com/anchore/syft/
+                  https://github.com/anchore/syft.git
+          {%endcomment%}
+          {% assign repo = tool.repoUrl | regex_replace:'^https?://github.com/','' | regex_replace:'(.git|/)$','' %}
+          <img src="https://img.shields.io/github/forks/{{repo}}?style=social&label=Forks&logo=github" alt="#forks"/>&nbsp;
+          <img src="https://img.shields.io/github/stars/{{repo}}?style=social&label=Stars&logo=github" alt="#stars"/>
+        {% elsif tool.repoUrl contains '://gist.github.com/' %}
+          {%comment%}
+              repo holds the "gistID" as last path-part segment, for eg:
+                  https://gist.github.com/jkowalleck/a0f874ee0a8af9a56a0e887631fc53d1
+                  https://gist.github.com/a0f874ee0a8af9a56a0e887631fc53d1
+                  https://gist.github.com/a0f874ee0a8af9a56a0e887631fc53d1/
+                  https://gist.github.com/a0f874ee0a8af9a56a0e887631fc53d1.git
+          {%endcomment%}
+          {% assign gistID = tool.repoUrl | regex_replace:'^https?://gist.github.com/','' | regex_replace:'(.git|/)$','' | split:'/' | last %}
+          <img src="https://img.shields.io/github/gist/stars/{{gistID}}?style=social&label=Stars&logo=github" alt="#stars"/>
+        {% elsif tool.repoUrl contains '://gitlab.com/' %}
+          {%comment%}
+              repo holds the "org/repo" name, for eg:
+                  https://gitlab.com/expliot_framework/expliot
+                  https://gitlab.com/expliot_framework/expliot/
+                  https://gitlab.com/expliot_framework/expliot.git
+          {%endcomment%}
+          {% assign repo = tool.repoUrl | regex_replace:'^https?://gitlab.com/','' | regex_replace:'(.git|/)$','' | url_encode %}
+          <img src="https://img.shields.io/gitlab/forks/{{repo}}?style=social&label=Forks&logo=gitlab" alt="#forks"/>&nbsp;
+          <img src="https://img.shields.io/gitlab/stars/{{repo}}?style=social&label=Stars&logo=gitlab" alt="#stars"/>&nbsp;
+        {% elsif tool.repoUrl contains '://bitbucket.org/' %}
+          {%comment%}noting we can do for this repo hoster.{%endcomment%}
+        {% endif %}
       </div>
     </a>
 </div> 


### PR DESCRIPTION
- NEW: starts for GitHub-Gist
  - based on: https://github.com/CycloneDX/cyclonedx.org/blob/26ff0be9ad9a40ac16ea677d3deab3f0ce345bbc/_data/tools.yml#L1952-L1959
  - result:  
    ![image](https://github.com/CycloneDX/cyclonedx.org/assets/2765863/106d1469-5fe7-49cd-b1f9-2ed72bb54f7c)
- NEW: forks and starts for GitLab-Repo:
  - based on: https://github.com/CycloneDX/cyclonedx.org/blob/26ff0be9ad9a40ac16ea677d3deab3f0ce345bbc/_data/tools.yml#L1502-L1509
  - result:  
    ![image](https://github.com/CycloneDX/cyclonedx.org/assets/2765863/22efc3a4-ae4c-48f7-ad63-e73454b542fc)
- REFACTORED: forks and stars for GitHub-Repo
  - based on: https://github.com/CycloneDX/cyclonedx.org/blob/26ff0be9ad9a40ac16ea677d3deab3f0ce345bbc/_data/tools.yml#L2-L10
  - result: 
    ![image](https://github.com/CycloneDX/cyclonedx.org/assets/2765863/5fa31ad3-0592-4d24-9b15-8f1335291ffc)
