### PR TITLE
Add Meta Package Manager

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1965,3 +1965,11 @@
   categories:
   - build-integration
   - opensource
+- name: Meta Package Manager
+  publisher: Kevin Deldycke
+  description: Export a SBOM of all packages installed on a Linux, macOS or Windows system.
+  websiteUrl: https://github.com/kdeldycke/meta-package-manager
+  repoUrl: https://github.com/kdeldycke/meta-package-manager
+  categories:
+  - build-integration
+  - opensource


### PR DESCRIPTION
Meta Package Manager is a multi-platform CLI which allows you to export a SBOM of all packages installed on a system: https://kdeldycke.github.io/meta-package-manager/usecase.html#sbom-software-bill-of-materials