### PR TITLE
Add Cyberwatch

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2057,6 +2057,13 @@
   repoUrl: https://github.com/IBM/cbomkit-theia
   categories:
   - opensource
+- name: Cyberwatch
+  publisher: Cyberwatch
+  description: Cyberwatch Vulnerability Manager is a comprehensive vulnerability management solution. It allows you to discover your assets, scan and prioritize vulnerabilities, make the right decisions and fix vulnerabilities.
+  websiteUrl: https://cyberwatch.fr/en/
+  categories:
+  - proprietary
+  - analysis
 
 # `description` will be truncated at 250 characters
 # `categories` values may be the keys from `tool-categories.yml` file


### PR DESCRIPTION
Add Cyberwatch vulnerability Manager.

Cyberwatch v14, now support CycloneDX 1.5 and 1.6

Documentation : https://docs.cyberwatch.fr/help/en/use_assets/use_asset_form/#sbom-file