### PR TITLE
Added Sunshine SBOM visualization tool

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -2075,6 +2075,14 @@
   - build-integration
   - distribute
   - transform
+- name: Sunshine
+  publisher: Luca Capacci
+  description: Sunshine is an open-source SBOM visualization tool.
+  websiteUrl: https://lucacapacci.github.io/Sunshine/
+  repoUrl: https://github.com/lucacapacci/Sunshine/
+  categories:
+  - opensource
+  - analysis
 
 # `description` will be truncated at 250 characters
 # `categories` values may be the keys from `tool-categories.yml` file


### PR DESCRIPTION
I made a new open-source visualization tool and I'd like it to be added to the official tools list. The tool is called Sunshine and is a SBOM visualization tool, with a sunburst chart and a table with components, vulnerabilities and licenses